### PR TITLE
Add dictionary tracking and improve menu

### DIFF
--- a/app.py
+++ b/app.py
@@ -58,6 +58,7 @@ def login():
         users[username] = {
             'letters': get_seeded_letters(today_key),
             'history': [],
+            'dictionary': [],  # store unique submitted words with scores
             'date': today_key,
             'last_submission': None,
             'tokens': 10,
@@ -117,7 +118,9 @@ def get_letters():
         "longest_word": user['longest_word'],
         "current_streak": user['current_streak'],
         "longest_streak": user['longest_streak'],
-        "achievements": user['achievements']
+        "achievements": user['achievements'],
+        "dictionary": user['dictionary'],
+        "dictionary_score": sum(entry['score'] for entry in user['dictionary'])
     })
 
 
@@ -150,6 +153,8 @@ def submit_word():
 
     score = calculate_word_score(word)
     user['history'].append(word)
+    if not any(entry['word'] == word for entry in user['dictionary']):
+        user['dictionary'].append({"word": word, "score": score})
     user['last_submission'] = today_key
     user['tokens'] += 1
     if len(word) == LETTER_POOL_SIZE:
@@ -183,7 +188,9 @@ def submit_word():
         "score": score,
         "tokens": user['tokens'],
         "achievements": user['achievements'],
-        "new_achievements": new_achievements
+        "new_achievements": new_achievements,
+        "dictionary": user['dictionary'],
+        "dictionary_score": sum(entry['score'] for entry in user['dictionary'])
     }
     print("Response Payload:", result)
     return jsonify(result)

--- a/index.html
+++ b/index.html
@@ -78,6 +78,14 @@
       font-size: 1em;
       border-bottom: 1px solid #333;
     }
+    #drawer button.close-btn {
+      position: absolute;
+      top: 10px;
+      left: 10px;
+      width: auto;
+      border-bottom: none;
+      font-size: 1.2em;
+    }
     #drawer button:hover {
       background: #009688;
     }
@@ -202,7 +210,8 @@
   </header>
   <button id="signin-btn" onclick="openLoginModal()">Sign In</button>
 
-    <nav id="drawer">
+  <nav id="drawer">
+      <button id="drawer-close" class="close-btn">&times;</button>
       <button onclick="togglePanel('stats')">Show Stats</button>
       <button onclick="togglePanel('dictionary')">My Dictionary</button>
       <button onclick="togglePanel('achievements')">Achievements</button>
@@ -224,7 +233,8 @@
     </div>
       <div id="dictionary">
         <h3>MY DICTIONARY</h3>
-        <p>Your words will appear here.</p>
+        <ul id="dictionary-list"></ul>
+        <p id="dictionary-total"></p>
       </div>
       <div id="achievements">
         <h3>ACHIEVEMENTS</h3>
@@ -278,6 +288,15 @@
     document.getElementById('menu-toggle').addEventListener('click', () => {
       document.getElementById('drawer').classList.toggle('open');
     });
+    document.getElementById('drawer-close').addEventListener('click', () => {
+      document.getElementById('drawer').classList.remove('open');
+    });
+    document.addEventListener('click', (e) => {
+      const drawer = document.getElementById('drawer');
+      if(drawer.classList.contains('open') && !drawer.contains(e.target) && e.target !== document.getElementById('menu-toggle')) {
+        drawer.classList.remove('open');
+      }
+    });
 
       function updateLocalStats(data) {
         if (!data) return;
@@ -302,6 +321,18 @@
           li.textContent = a;
           list.appendChild(li);
         });
+      }
+
+      function updateDictionaryList(words, total) {
+        const list = document.getElementById('dictionary-list');
+        const totalEl = document.getElementById('dictionary-total');
+        list.innerHTML = '';
+        words.forEach(entry => {
+          const li = document.createElement('li');
+          li.textContent = `${entry.word} (+${entry.score})`;
+          list.appendChild(li);
+        });
+        totalEl.innerText = words.length ? `Total Score: ${total}` : '';
       }
 
     let selectedTiles = [];
@@ -361,6 +392,7 @@
           document.getElementById('longest-word').innerText = data.longest_word || '–';
           document.getElementById('current-streak').innerText = data.current_streak || 0;
           document.getElementById('longest-streak').innerText = data.longest_streak || 0;
+          updateDictionaryList(data.dictionary || [], data.dictionary_score || 0);
         });
     }
 
@@ -385,6 +417,7 @@
               });
               updateAchievementsList();
             }
+            updateDictionaryList(data.dictionary || [], data.dictionary_score || 0);
             getData();
           } else {
             document.getElementById('result').innerText = data.message;


### PR DESCRIPTION
## Summary
- maintain a dictionary for each player server-side and return it via `/get-letters`
- show dictionary list with word scores and total score
- prevent duplicate words from being added to the dictionary
- add close button to the slide-out menu and close when clicking outside

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*